### PR TITLE
CPU usage improvement and whitespace cleanup

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -27,9 +27,7 @@ int main() {
     }
 
     const int width = 1800;
-
     const int height = 1050;
-
     SDL_Window *window;
     SDL_Renderer *renderer;
 
@@ -62,7 +60,7 @@ int main() {
                     currentView = -1;
                     break;
                 case SDL_KEYDOWN:
-                    if (event.key.keysym.sym == SDLK_ESCAPE)                     {
+                    if (event.key.keysym.sym == SDLK_ESCAPE) {
                         if (currentView == 1) {
                             // Break out of main view.
                             currentView = 0;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -7,105 +7,124 @@
 #include "main_view.h"
 
 int main() {
-  if (TTF_Init() == -1) {
-    printf("TTF_Init: %s\n", TTF_GetError());
-    return 2;
-  }
+    if (TTF_Init() == -1) {
+        printf("TTF_Init: %s\n", TTF_GetError());
+        return 2;
+    }
 
-  // load support for the JPG and PNG image formats
-  int flags = IMG_INIT_JPG | IMG_INIT_PNG;
-  int initialized = IMG_Init(flags);
-  if ((initialized & flags) != flags) {
-    printf("IMG_Init: Failed to init required jpg and png support!\n");
-    printf("IMG_Init: %s\n", IMG_GetError());
-    return 1;
-  }
+    // load support for the JPG and PNG image formats
+    int flags = IMG_INIT_JPG | IMG_INIT_PNG;
+    int initialized = IMG_Init(flags);
+    if ((initialized & flags) != flags) {
+        printf("IMG_Init: Failed to init required jpg and png support!\n");
+        printf("IMG_Init: %s\n", IMG_GetError());
+        return 1;
+    }
 
-  if (SDL_Init(SDL_INIT_EVERYTHING) != 0) {
-    SDL_Log("Unable to initialize SDL: %s", SDL_GetError());
-    return 1;
-  }
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        SDL_Log("Unable to initialize SDL: %s", SDL_GetError());
+        return 1;
+    }
 
-  const int width = 1800;
+    const int width = 1800;
 
-  const int height = 1050;
+    const int height = 1050;
 
-  SDL_Window *window;
-  SDL_Renderer *renderer;
+    SDL_Window *window;
+    SDL_Renderer *renderer;
 
-  if (SDL_CreateWindowAndRenderer(width, height, SDL_WINDOW_RESIZABLE, &window, &renderer)) {
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create window and renderer: %s", SDL_GetError());
-    return 3;
-  }
+    if (SDL_CreateWindowAndRenderer(width, height, SDL_WINDOW_RESIZABLE, &window, &renderer)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create window and renderer: %s", SDL_GetError());
+        return 3;
+    }
 
-  SDL_Surface* surf;
-  surf = SDL_CreateRGBSurfaceWithFormat(0, width, height, 32, SDL_PIXELFORMAT_RGBA32);
-  if (surf == NULL) {
-    SDL_Log("SDL_CreateRGBSurfaceWithFormat() failed: %s", SDL_GetError());
-    return 1;
-  }
+    SDL_Surface* surf;
+    surf = SDL_CreateRGBSurfaceWithFormat(0, width, height, 32, SDL_PIXELFORMAT_RGBA32);
+    if (surf == NULL) {
+        SDL_Log("SDL_CreateRGBSurfaceWithFormat() failed: %s", SDL_GetError());
+        return 1;
+    }
 
-  bool done = false;
+    bool redraw;
 
-  // Create views that user will see
-  int currentView = 0;
-  MenuView menuView(surf, currentView);
-  MainView mainView(surf);
+    // Create views that user will see
+    int currentView = 0;
+    MenuView menuView(surf, currentView);
+    MainView mainView(surf);
 
-  while (currentView >= 0) {
-    SDL_Event event;
-    while (SDL_PollEvent(&event)) {
-        switch (event.type) {
-            case SDL_QUIT:
-                // Window was closed
-                currentView = -1;
-                break;
-            case SDL_MOUSEBUTTONDOWN:
-                if (event.button.clicks == 1) {
-                    menuView.handleClicks(event.button);
-                }
-				break;
-			case SDL_WINDOWEVENT:
-				// Window is resized.
-				if (event.window.event == SDL_WINDOWEVENT_RESIZED) {
-					int newWidth = event.window.data1;
-					int newHeight = event.window.data2;
-					surf = SDL_CreateRGBSurfaceWithFormat(0, newWidth, newHeight, 32, SDL_PIXELFORMAT_RGBA32);
-          menuView.handleResize(surf);
-				}
-				break;
-
+    while (currentView >= 0) {
+        redraw = false;
+        SDL_Event event;
+        while (SDL_PollEvent(&event)) {
+            switch (event.type) {
+                case SDL_QUIT:
+                    // Window was closed
+                    currentView = -1;
+                    break;
+                case SDL_KEYDOWN:
+                    if (event.key.keysym.sym == SDLK_ESCAPE)                     {
+                        if (currentView == 1) {
+                            // Break out of main view.
+                            currentView = 0;
+                            redraw = true;
+                        } else if (currentView == 0) {
+                            // Break out of menu view (exit the program.)
+                            currentView = -1;
+                        }
+                    }
+                    break;
+                case SDL_MOUSEBUTTONDOWN:
+                    if (event.button.clicks == 1) {
+                        menuView.handleClicks(event.button);
+                    }
+                    redraw = true;
+                    break;
+                case SDL_WINDOWEVENT:
+                    // Window is resized.
+                    if (event.window.event == SDL_WINDOWEVENT_RESIZED) {
+                        int newWidth = event.window.data1;
+                        int newHeight = event.window.data2;
+                        surf = SDL_CreateRGBSurfaceWithFormat(0, newWidth, newHeight, 32, SDL_PIXELFORMAT_RGBA32);
+                        menuView.handleResize(surf);
+                    }  else if (event.window.event == SDL_WINDOWEVENT_EXPOSED) {
+                        // The window was exposed and should be repainted.
+                        // std::cout << event.window.event << ": must redraw\n";
+                        redraw = true;
+                    }
+                    break;
+                case SDL_MOUSEMOTION:
+                    redraw = true;
+                    break;
+            }
         }
+
+        if (redraw) {
+            if (currentView == 0) {
+                menuView.draw(surf);
+            } else if (currentView == 1) {
+                mainView.draw(surf);
+            }
+
+            SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, surf);
+
+            if (texture == NULL) {
+                fprintf(stderr, "CreateTextureFromSurface failed: %s\n", SDL_GetError());
+                exit(1);
+            }
+
+            SDL_RenderCopy(renderer, texture, nullptr, nullptr);
+            SDL_RenderPresent(renderer);
+            SDL_DestroyTexture(texture);
+        }
+        SDL_Delay(1000/30);
     }
 
-    if (currentView == 0) {
-        menuView.draw(surf);
-    } else if (currentView == 1) {
-        mainView.draw(surf);
-    }
-
-    SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, surf);
-
-    if (texture == NULL) {
-      fprintf(stderr, "CreateTextureFromSurface failed: %s\n", SDL_GetError());
-      exit(1);
-    }
-
-    SDL_RenderCopy(renderer, texture, nullptr, nullptr);
-    SDL_RenderPresent(renderer);
-    SDL_DestroyTexture(texture);
-
-    SDL_Delay(1000/30);
-  }
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(window);
+    IMG_Quit();
+    TTF_Quit();
+    SDL_Quit();
 
 
-
-  SDL_DestroyRenderer(renderer);
-  SDL_DestroyWindow(window);
-  IMG_Quit();
-  TTF_Quit();
-  SDL_Quit();
-
-
-  std::cout << "Program finished.\n";
+    std::cout << "Program finished.\n";
 }

--- a/src/main_view.cpp
+++ b/src/main_view.cpp
@@ -2,18 +2,18 @@
 #include "asset_manager.h"
 
 MainView::MainView(SDL_Surface* screen) {
-		boundaryMainView = SDL_Rect{0, 0, screen->w, screen->h};
+    boundaryMainView = SDL_Rect{0, 0, screen->w, screen->h};
 };
 
 void MainView::draw(SDL_Surface* screen) {
-		SDL_FillRect(screen, &boundaryMainView, SDL_MapRGB(screen->format, 0, 0, 0));
+    SDL_FillRect(screen, &boundaryMainView, SDL_MapRGB(screen->format, 0, 0, 0));
 };
 
 SDL_Rect MainView::boundary() const {
-		return boundaryMainView;
+    return boundaryMainView;
 
 };
 
 void MainView::handleResize(SDL_Surface* screen) {
-		boundaryMainView = SDL_Rect{0, 0, screen->w, screen->h};
+    boundaryMainView = SDL_Rect{0, 0, screen->w, screen->h};
 }

--- a/src/main_view.h
+++ b/src/main_view.h
@@ -4,13 +4,13 @@
 #include "view.h"
 
 class MainView : public View {
-	public:
-		MainView(SDL_Surface* screen);
-		void draw(SDL_Surface* screen);
-		SDL_Rect boundary() const;
-		void handleResize(SDL_Surface* screen);
-	private:
-		SDL_Rect boundaryMainView;
+    public:
+        MainView(SDL_Surface* screen);
+        void draw(SDL_Surface* screen);
+        SDL_Rect boundary() const;
+        void handleResize(SDL_Surface* screen);
+    private:
+        SDL_Rect boundaryMainView;
 };
 
 #endif // MAIN_VIEW_H_INCLUDED

--- a/src/menu_view.cpp
+++ b/src/menu_view.cpp
@@ -12,19 +12,25 @@ MenuView::MenuView(SDL_Surface* surf, int& currentView)
                             "Quit",
                             SDL_Color{112, 191, 255},
                             [&currentView] () {currentView = -1;},
-                            -75, 100)) {}
+                            -75, 100)),
+      heroicImage(nullptr) {
+      const AssetManager& am = getAssetManager();
+      heroicImage = am.getImage("Apollo_15_flag,_rover,_LM,_Irwin.jpg");
+}
 
+MenuView::~MenuView() {
+      if (heroicImage) {
+          SDL_FreeSurface(heroicImage);
+      }
+}
 
 void MenuView::draw(SDL_Surface* screen) {
     // Draw HEROIC background image
-    const AssetManager& am = getAssetManager();
-    SDL_Surface* heroicImage = am.getImage("Apollo_15_flag,_rover,_LM,_Irwin.jpg");
     float aspectRatio = heroicImage->w / heroicImage->h;
     SDL_Rect blitDestinationRect = SDL_Rect{0, 0, screen->w, int(screen->w/aspectRatio)};
     blitDestinationRect.x = screen->w / 2 - blitDestinationRect.w / 2;
     blitDestinationRect.y = screen->h / 2 - blitDestinationRect.h / 2;
     SDL_BlitScaled(heroicImage, nullptr, screen, &blitDestinationRect);
-	SDL_FreeSurface(heroicImage);
 
     // Draw the buttons
     startButton.draw(screen);

--- a/src/menu_view.h
+++ b/src/menu_view.h
@@ -8,6 +8,7 @@
 class MenuView : public View {
     public:
         MenuView(SDL_Surface* surf, int& currentView);
+        ~MenuView();
         void draw(SDL_Surface* screen);
         SDL_Rect boundary() const;
         void handleClicks(SDL_MouseButtonEvent& mouseButtonEvent);
@@ -16,6 +17,7 @@ class MenuView : public View {
     private:
         ButtonView startButton;
         ButtonView quitButton;
+        SDL_Surface* heroicImage;
 };
 
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -9,9 +9,11 @@ bool View::mouseOver() const {
     }
     return false;
 }
+
 void View::handleClicks(SDL_MouseButtonEvent& mouseButtonEvent) {
 
 }
+
 void View::handleResize(SDL_Surface* newSurface) {
-	
+
 }

--- a/src/view.h
+++ b/src/view.h
@@ -4,14 +4,14 @@
 #include <SDL.h>
 
 class View {
-public:
-    virtual void draw(SDL_Surface* screen) = 0;
-    virtual SDL_Rect boundary() const = 0;
-    virtual void handleClicks(SDL_MouseButtonEvent& mouseButtonEvent);
-	virtual void handleResize(SDL_Surface* newSurface);
-public:
-    // Non-virtual functions.
-    bool mouseOver() const;
+    public:
+        virtual void draw(SDL_Surface* screen) = 0;
+        virtual SDL_Rect boundary() const = 0;
+        virtual void handleClicks(SDL_MouseButtonEvent& mouseButtonEvent);
+        virtual void handleResize(SDL_Surface* newSurface);
+    public:
+        // Non-virtual functions.
+        bool mouseOver() const;
 };
 
 #endif // VIEW_H_INCLUDED


### PR DESCRIPTION
This PR accomplishes the following:

- **The program consumes no CPU when it is idle.**  Instead, it now responds to mouseover and window exposed events in order to know when to repaint.  Keep in mind that this means that views will now have to signal Main.cpp if they need to paint something new out of band.  (I think that for this program, that will be rare.)

- **The hero image is only allocated once, and it is only destroyed once.**  While the hero image no longer leaks memory after the changes from earlier yesterday, it still reloads the same image over and over unnecessarily.

- **Whitespace cleanup.**  You can have tabs only, or spaces only, but don't mix them like you guys were.  (In fact, _forget it_; use spaces only, no tabs.) Trailing whitespace is gone, and DOS line endings (CR + LF) and now Unix line endings (LF.)

What has all this wrought?  "A clean program, madam, if you can keep it."
(With apologies to Ben Franklin.)